### PR TITLE
add first and final line separators

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -291,19 +291,21 @@ pub fn default_format(
         let sep = style.line_separator();
         let final_sep = style.final_line_separator();
 
-        let mut lines = lines.iter().peekable();
+        let mut lines = lines.iter();
 
-        write!(buf, "{}{} {}", first_sep, prefix, lines.next().unwrap())?;
-
-        while let Some(line) = lines.next() {
-            if lines.peek().is_some() {
-                write!(buf, "{}{}", sep, line)?;
-            } else {
-                write!(buf, "{}{}", final_sep, line)?;
-            }
+        if let Some(first_line) = lines.next() {
+            write!(buf, "{}{} {}", first_sep, prefix, first_line)?;
         }
 
-        writeln!(buf)?;
+        let last_line = lines.next_back();
+
+        for line in lines {
+            write!(buf, "{}{}", sep, line)?;
+        }
+
+        if let Some(last_line) = last_line {
+            writeln!(buf, "{}{}", final_sep, last_line)?;
+        }
     }
 
     Ok(())


### PR DESCRIPTION
adds the ability to have a specific line separator on first and last lines and also pads single line messages to align with the first line separator

no doc comments on the functions i added as i did this for my personal use, but i can write some if you wish to merge this pr

example usage:

```rs
pub struct LogStyle;

impl CologStyle for LogStyle {
  fn level_token(&self, level: &Level) -> &str {
    match level {
      Level::Trace => "TRC",
      Level::Debug => "DBG",
      Level::Info => "INF",
      Level::Warn => "WRN",
      Level::Error => "ERR",
    }
  }

  fn prefix_token(&self, level: &Level) -> String {
    self.level_color(level, self.level_token(level))
  }

  fn first_line_separator(&self) -> String {
    "╭ ".to_string()
  }

  fn line_separator(&self) -> String {
    "\n│     ".to_string()
  }

  fn final_line_separator(&self) -> String {
    "\n╰     ".to_string()
  }
}
```

```
  ERR error message
  ERR error with fmt: 42
  WRN warn message
  INF info message
  DBG debug message
  TRC trace message
╭ INF multi line demonstration
╰     here
╭ INF more
│     multi
│     line
│     here
╰     here
```